### PR TITLE
Update sh.py, fixed import builtins on osx

### DIFF
--- a/pyqode/python/modes/sh.py
+++ b/pyqode/python/modes/sh.py
@@ -7,7 +7,14 @@ highlight decorators and self parameters.
 It is approximately 3 time faster then :class:`pyqode.core.modes.PygmentsSH`.
 
 """
-import builtins
+
+try:
+    #it works on windows
+    import builtins
+except ImportError:
+    #it works on osx
+    builtins = __import__('__builtin__')
+
 import re
 from pyqode.core.api import SyntaxHighlighter as BaseSH
 from pyqode.core.api import TextBlockHelper


### PR DESCRIPTION
First it all, excellent project, it's great!!!!!!!!! thanks to share

I have an issue in the sh.py file:

the original "import builtins" only works on windows (e.g. using WinPython distribution) to me and not on OSX. 
Adding the above change, it solves its use in OS X (e.g. anaconda and [GCC 4.2.1 (Apple Inc. build 5577)])

```python
try:
    #it works on windows
    import builtins
except ImportError:
    #it works on osx
    builtins = __import__('__builtin__')
```