### PR TITLE
Fix #74 Jedi API incompatibilities

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,5 @@ Colin Duquesnooy (@ColinDuquesnoy) <colin.duquesnoy@gmail.com>
 
 Contributors
 ============
+
+Fynn Mazurkiewicz <FynnMazurkiewicz@'Googles-Email-Service'.com>

--- a/pyqode/python/backend/workers.py
+++ b/pyqode/python/backend/workers.py
@@ -76,7 +76,7 @@ _old_definitions = {}
 
 
 def _extract_def(d, path):
-    d_line, d_column = d.start_pos
+    d_line, d_column = d.line, d.column
     # use full name for import type
     if d.type == 'function':
         try:

--- a/test/test_backend/test_workers.py
+++ b/test/test_backend/test_workers.py
@@ -2,6 +2,8 @@
 Test all workers in pyqode.python.backend.workers.
 """
 import sys
+
+import jedi
 from pyqode.core.modes import CheckerMessages
 from pyqode.core.share import Definition
 
@@ -70,8 +72,9 @@ def test_extract_def():
     editor.show()
     app.exec()
     """
-    results = workers._extract_def(workers.defined_names({'code': code, 'path': __file__}),"")
-    assert results
+    for definition in jedi.defined_names(code):
+        result = workers._extract_def(definition, "")
+        assert result
 
 def test_defined_names():
     filename = __file__

--- a/test/test_backend/test_workers.py
+++ b/test/test_backend/test_workers.py
@@ -60,6 +60,19 @@ def test_goto_assignments():
     assert len(results) == 0
 
 
+def test_extract_def():
+    code = """
+    import pyqode.python.widgets
+    import PyQt5.QtWidgets as QtWidgets
+    app = QtWidgets.QApplication([])
+    editor = pyqode.python.widgets.PyCyodeEdit()
+    editor.file.open(__file__)
+    editor.show()
+    app.exec()
+    """
+    results = workers._extract_def(workers.defined_names({'code': code, 'path': __file__}),"")
+    assert results
+
 def test_defined_names():
     filename = __file__
     with open(filename, 'r', encoding='utf-8') as file:


### PR DESCRIPTION
This PR fixes [Python worker fails in _extract_def #74](https://github.com/pyQode/pyQode/issues/74#issuecomment-309213112)

The name of two attributes of `Definition` had changed.
