### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/pyqode/python/__init__.py
+++ b/pyqode/python/__init__.py
@@ -7,4 +7,4 @@ completion, documentation lookups, code linters, and so on...).
 
 """
 
-__version__ = '2.12.0'
+__version__ = '2.12.1a1'

--- a/pyqode/python/backend/workers.py
+++ b/pyqode/python/backend/workers.py
@@ -38,7 +38,14 @@ def calltips(request_data):
     # encoding = request_data['encoding']
     encoding = 'utf-8'
     # use jedi to get call signatures
-    script = jedi.Script(code, line, column, path, encoding)
+    try:
+        script = jedi.Script(code, line, column, path, encoding)
+    except ValueError:
+        # Is triggered when an the position is invalid, for example if the
+        # column is larger or equal to the line length. This may be due to a
+        # bug elsewhere in PyQode, but this at least suppresses the error
+        # message, and does not seem to hve any adverse side effects.
+        return []
     signatures = script.call_signatures()
     for sig in signatures:
         results = (str(sig.module_name), str(sig.name),
@@ -315,7 +322,7 @@ class JediCompletionProvider:
             script = jedi.Script(code, line + 1, column, path, encoding)
             completions = script.completions()
             print('completions: %r' % completions)
-        except jedi.NotFoundError:
+        except RuntimeError:
             completions = []
         for completion in completions:
             ret_val.append({

--- a/pyqode/python/modes/autoindent.py
+++ b/pyqode/python/modes/autoindent.py
@@ -60,7 +60,7 @@ class PyAutoIndentMode(AutoIndentMode):
             elif line.endswith("\\"):
                 # if user typed \ and press enter -> indent is always
                 # one level higher
-                post += self.editor.tab_length * " "
+                post += self._single_indent
             elif (fullline.endswith((')', '}', ']')) and
                     lastword.endswith((')', '}', ']'))):
                 post = self._handle_indent_after_paren(cursor, post)
@@ -260,11 +260,11 @@ class PyAutoIndentMode(AutoIndentMode):
         open_line_txt = self._helper.line_text(open_line)
         open_line_indent = len(open_line_txt) - len(open_line_txt.lstrip())
         if prev_open:
-            post = (open_line_indent + self.editor.tab_length) * ' '
+            post = open_line_indent * self._indent_char + self._single_indent
         elif next_close and prev_char != ',':
-            post = open_line_indent * ' '
+            post = open_line_indent * self._indent_char
         elif tc.block().blockNumber() == open_line:
-            post = open_symbol_col * ' '
+            post = open_symbol_col * self._indent_char
 
         # adapt indent if cursor on closing line and next line have same
         # indent -> PEP8 compliance
@@ -272,12 +272,12 @@ class PyAutoIndentMode(AutoIndentMode):
             txt = self._helper.line_text(close_line)
             bn = tc.block().blockNumber()
             flg = bn == close_line
-            next_indent = self._helper.line_indent(bn + 1) * ' '
+            next_indent = self._helper.line_indent(bn + 1) * self._indent_char
             if flg and txt.strip().endswith(':') and next_indent == post:
                 # | look at how the previous line ( ``':'):`` ) was
                 # over-indented, this is actually what we are trying to
                 # achieve here
-                post += self.editor.tab_length * ' '
+                post += self._single_indent
 
         # breaking string
         if next_char in ['"', "'"]:
@@ -319,19 +319,19 @@ class PyAutoIndentMode(AutoIndentMode):
         # break string with a '\' at the end of the original line, always
         # breaking strings enclosed by parens is done in the
         # _handle_between_paren method
-        n = self.editor.tab_length
         pre = '%s \\' % char
-        post += n * ' '
+        post += self._single_indent
         if fullline.endswith(':'):
-            post += n * " "
+            post += self._single_indent
         post += char
         return post, pre
 
     def _handle_new_scope_indentation(self, cursor, fullline):
         try:
-            indent = (self._get_indent_of_opening_paren(cursor) +
-                      self.editor.tab_length)
-            post = indent * " "
+            post = (
+                self._get_indent_of_opening_paren(cursor) * self._indent_char +
+                self._single_indent
+            )
         except TypeError:
             # e.g indent is None (meaning the line does not ends with ):, ]:
             # or }:
@@ -349,15 +349,15 @@ class PyAutoIndentMode(AutoIndentMode):
             while not check_kw_in_line(kw, l) and ln:
                 ln -= 1
                 l = self._helper.line_text(ln)
-            indent = (len(l) - len(l.lstrip())) * " "
-            indent += self.editor.tab_length * " "
+            indent = (len(l) - len(l.lstrip())) * self._indent_char
+            indent += self._single_indent
             post = indent
         return post
 
     def _handle_indent_after_paren(self, cursor, post):
         indent = self._get_indent_of_opening_paren(cursor)
         if indent is not None:
-            post = indent * " "
+            post = indent * self._indent_char
         return post
 
     def _handle_indent_in_statement(self, fullline, lastword, post, pre):
@@ -366,7 +366,7 @@ class PyAutoIndentMode(AutoIndentMode):
                 pre += " \\"
             else:
                 pre += '\\'
-        post += self.editor.tab_length * " "
+        post += self._single_indent
         if fullline.endswith(':'):
-            post += self.editor.tab_length * " "
+            post += self._single_indent
         return post, pre

--- a/pyqode/python/modes/indenter.py
+++ b/pyqode/python/modes/indenter.py
@@ -47,15 +47,7 @@ class PyIndenterMode(IndenterMode):
             if cursor.hasSelection():
                 self.indent_selection(cursor)
             else:
-                # simply insert indentation at the cursor position
-                tab_len = self.editor.tab_length
-                cursor.beginEditBlock()
-                if self.editor.use_spaces_instead_of_tabs:
-                    cursor.insertText(tab_len * " ")
-                else:
-                    cursor.insertText('\t')
-                cursor.endEditBlock()
-                self.editor.setTextCursor(cursor)
+                cursor.insertText(self._single_indent)
 
     def unindent(self):
         """
@@ -63,9 +55,12 @@ class PyIndenterMode(IndenterMode):
         """
         if self.tab_always_indent:
             cursor = self.editor.textCursor()
+            cursor.beginEditBlock()
             if not cursor.hasSelection():
                 cursor.select(cursor.LineUnderCursor)
             self.unindent_selection(cursor)
+            cursor.endEditBlock()
+            self.editor.setTextCursor(cursor)
         else:
             super(PyIndenterMode, self).unindent()
 


### PR DESCRIPTION
This PR is linked to pyQode/pyqode.core#161. In a nutshell:

- Recent versions of JEDI no longer throw `jedi.NotFoundError`s but `RuntimeError`s
- Fixed indentation modes for tab-based indentation